### PR TITLE
_wagtail_site to wagtail_site and ababic's suggested change to wagtailcore_tags

### DIFF
--- a/wagtail/admin/tests/test_jinja2.py
+++ b/wagtail/admin/tests/test_jinja2.py
@@ -30,7 +30,7 @@ class TestCoreJinja(TestCase):
         site = Site.objects.get(is_default_site=True)
 
         request = HttpRequest()
-        request._wagtail_site = site
+        request.wagtail_site = site
         request.user = user or AnonymousUser()
         return request
 

--- a/wagtail/contrib/routable_page/tests.py
+++ b/wagtail/contrib/routable_page/tests.py
@@ -214,10 +214,10 @@ class TestRoutablePageTemplateTagForSecondSiteAtSameRoot(TestCase):
 
         self.rf = RequestFactory()
         self.request = self.rf.get(self.routable_page.url)
-        self.request._wagtail_site = Site.find_for_request(self.request)
+        self.request.wagtail_site = Site.find_for_request(self.request)
         self.context = {'request': self.request}
 
-        self.request._wagtail_site = second_site
+        self.request.wagtail_site = second_site
 
     def test_templatetag_reverse_index_route(self):
         url = routablepageurl(self.context, self.routable_page,
@@ -275,7 +275,7 @@ class TestRoutablePageTemplateTagForSecondSiteAtDifferentRoot(TestCase):
         self.request = self.rf.get(self.routable_page.url)
         self.context = {'request': self.request}
 
-        self.request._wagtail_site = second_site
+        self.request.wagtail_site = second_site
 
 
     def test_templatetag_reverse_index_route(self):

--- a/wagtail/contrib/settings/tests/test_templates.py
+++ b/wagtail/contrib/settings/tests/test_templates.py
@@ -30,7 +30,7 @@ class TemplateTestCase(TestCase, WagtailTestUtils):
         if site is None:
             site = self.default_site
         request = HttpRequest()
-        request._wagtail_site = site
+        request.wagtail_site = site
         return request
 
     def render(self, request, string, context=None, site=None):
@@ -174,7 +174,7 @@ class TestSettingsJinja(TemplateTestCase):
             else:
                 site = Site.objects.get(is_default_site=True)
             request = HttpRequest()
-            request._wagtail_site = site
+            request.wagtail_site = site
             context['request'] = request
 
         template = self.engine.from_string(string)
@@ -221,7 +221,7 @@ class TestSettingsJinja(TemplateTestCase):
         # site, dummy request
         site = Site.objects.get(is_default_site=True)
         request = HttpRequest()
-        request._wagtail_site = site
+        request.wagtail_site = site
 
         # run extra query before hand
         Site.find_for_request(request)

--- a/wagtail/contrib/sitemaps/sitemap_generator.py
+++ b/wagtail/contrib/sitemaps/sitemap_generator.py
@@ -14,7 +14,7 @@ class Sitemap(DjangoSitemap):
         # (for backwards compatibility from before last_published_at was added)
         return (obj.last_published_at or obj.latest_revision_created_at)
 
-    def get_wagtail_site(self):
+    def getwagtail_site(self):
         site = getattr(self.request, 'site', None)
         if site is None:
             from wagtail.core.models import Site
@@ -25,7 +25,7 @@ class Sitemap(DjangoSitemap):
 
     def items(self):
         return (
-            self.get_wagtail_site()
+            self.getwagtail_site()
             .root_page
             .get_descendants(inclusive=True)
             .live()

--- a/wagtail/contrib/sitemaps/tests.py
+++ b/wagtail/contrib/sitemaps/tests.py
@@ -54,7 +54,7 @@ class TestSitemapGenerator(TestCase):
 
     def get_request_and_django_site(self, url):
         request = RequestFactory().get(url)
-        request._wagtail_site = self.site
+        request.wagtail_site = self.site
         return request, get_current_site(request)
 
     def test_items(self):

--- a/wagtail/core/middleware.py
+++ b/wagtail/core/middleware.py
@@ -18,6 +18,6 @@ class SiteMiddleware(MiddlewareMixin):
         )
 
         try:
-            request._wagtail_site = Site.find_for_request(request)
+            request.wagtail_site = Site.find_for_request(request)
         except Site.DoesNotExist:
-            request._wagtail_site = None
+            request.wagtail_site = None

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -110,16 +110,16 @@ class Site(models.Model):
         NB this means that high-numbered ports on an extant hostname may
         still be routed to a different hostname which is set as the default
 
-        The site will be cached via request._wagtail_site
+        The site will be cached via request.wagtail_site
         """
 
         if request is None:
             return None
 
-        if not hasattr(request, '_wagtail_site'):
+        if not hasattr(request, 'wagtail_site'):
             site = Site._find_for_request(request)
-            setattr(request, '_wagtail_site', site)
-        return request._wagtail_site
+            setattr(request, 'wagtail_site', site)
+        return request.wagtail_site
 
     @staticmethod
     def _find_for_request(request):

--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -173,4 +173,4 @@ def wagtail_site(context):
     """
         Returns the Site object for the given request
     """
-    return Site.find_for_request(request=context.request)
+    return Site.find_for_request(request=context['request'])

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -291,7 +291,7 @@ class TestRouting(TestCase):
         self.assertEqual(christmas_page.get_site(), events_site)
 
         request = HttpRequest()
-        request._wagtail_site = events_site
+        request.wagtail_site = events_site
 
         self.assertEqual(
             christmas_page.get_url_parts(request=request),
@@ -299,7 +299,7 @@ class TestRouting(TestCase):
         )
 
         request2 = HttpRequest()
-        request2._wagtail_site = second_events_site
+        request2.wagtail_site = second_events_site
         self.assertEqual(
             christmas_page.get_url_parts(request=request2),
             (second_events_site.id, 'http://second-events.example.com', '/christmas/')
@@ -344,7 +344,7 @@ class TestRouting(TestCase):
 
         request = HttpRequest()
         request.user = AnonymousUser()
-        request._wagtail_site = Site.objects.first()
+        request.wagtail_site = Site.objects.first()
 
         response = christmas_page.serve(request)
         self.assertEqual(response.status_code, 200)

--- a/wagtail/core/tests/tests.py
+++ b/wagtail/core/tests/tests.py
@@ -54,7 +54,7 @@ class TestPageUrlTags(TestCase):
 
         # 'request' object in context, but site is None
         request = HttpRequest()
-        request._wagtail_site = None
+        request.wagtail_site = None
         result = tpl.render(template.Context({'page': page, 'request': request}))
         self.assertIn('<a href="/events/">Events</a>', result)
 
@@ -82,7 +82,7 @@ class TestPageUrlTags(TestCase):
         new_christmas_page = Page(title='Christmas', slug='christmas')
         new_home_page.add_child(instance=new_christmas_page)
         request = HttpRequest()
-        request._wagtail_site = second_site
+        request.wagtail_site = second_site
         url = slugurl(context=template.Context({'request': request}), slug='christmas')
         self.assertEqual(url, '/christmas/')
 
@@ -91,7 +91,7 @@ class TestPageUrlTags(TestCase):
         new_home_page = home_page.copy(update_attrs={'title': "New home page", 'slug': 'new-home'})
         second_site = Site.objects.create(hostname='site2.example.com', root_page=new_home_page)
         request = HttpRequest()
-        request._wagtail_site = second_site
+        request.wagtail_site = second_site
         # There is no page with this slug on the current site, so this
         # should return an absolute URL for the page on the first site.
         url = slugurl(slug='christmas', context=template.Context({'request': request}))
@@ -109,7 +109,7 @@ class TestPageUrlTags(TestCase):
     def test_slugurl_with_null_site_in_request(self):
         # 'request' object in context, but site is None
         request = HttpRequest()
-        request._wagtail_site = None
+        request.wagtail_site = None
         result = slugurl(template.Context({'request': request}), 'events')
         self.assertEqual(result, '/events/')
 


### PR DESCRIPTION
rename `_wagtail_site` to `wagtail_site` to preserve usability with `django.core.context_processors.request` in templates. Change new tag in wagtailcore_tags to use bracket notation for context as suggested by ababic in https://github.com/wagtail/wagtail/pull/5673#commitcomment-36153317